### PR TITLE
FIxes default recieve port

### DIFF
--- a/src/oscmidi.cpp
+++ b/src/oscmidi.cpp
@@ -432,7 +432,7 @@ int main(int argc, char** argv)
    */
   
   if (arguments.rport.size() == 0) {
-    arguments.rport == arguments.port;
+    arguments.rport = arguments.port;
   }
   
   lo_server_thread st;


### PR DESCRIPTION
This patch changes an equality check (==) with an assignment (=) so that the default receive port assignment works.
